### PR TITLE
[HOT FIX] Update integration-dev.yml

### DIFF
--- a/.github/workflows/integration-dev.yml
+++ b/.github/workflows/integration-dev.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           ref: dev
       - uses: dart-lang/setup-dart@v1
+        with:
+            sdk: 2.19.0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'


### PR DESCRIPTION
Update dart sdk action to use dart-SDK version 2.19.0.

This is the last version that genezio supports for now.