### PR TITLE
NPM init ts-python project and add @types/node as dependency

### DIFF
--- a/projects/typescript-srv-python-client/server/package-lock.json
+++ b/projects/typescript-srv-python-client/server/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "server",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/node": "^20.3.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+    }
+  }
+}

--- a/projects/typescript-srv-python-client/server/package.json
+++ b/projects/typescript-srv-python-client/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "^20.3.1"
+  }
+}


### PR DESCRIPTION
Before, typescript would not recognize @types/node because it was not installed. This would return an error at deploy time.