### PR TITLE
Fix process kill on Windows

### DIFF
--- a/genezio.py
+++ b/genezio.py
@@ -5,7 +5,7 @@ import re
 import socket
 import time
 import os
-import random
+from utils import kill_process
 
 # We are using shell=True on Windows for subprocess.run()
 use_shell = os.name == 'nt'
@@ -131,7 +131,7 @@ def genezio_local(args=[]):
 
         if process.returncode != None:
             print("process exited with code: " + str(process.returncode))
-            process.kill()
+            kill_process(process)
             with open(stdout_file, "r") as f:
                 stdout = f.read()
                 print(stdout)
@@ -149,7 +149,7 @@ def genezio_local(args=[]):
         end = time.time()
         if end - start > 60:
             print("Timeout while waiting for localhost.")
-            process.kill()
+            kill_process(process)
             with open(stdout_file, "r") as f:
                 stdout = f.read()
                 print(stdout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0
 requests==2.28.2
 termcolor==2.2.0
+psutil==5.9.6

--- a/test_binary_dependency.py
+++ b/test_binary_dependency.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script
+from utils import run_node_script, kill_process
 
 def test_binary_dependency():
     print("Starting binary_dependency test...")
@@ -36,7 +36,7 @@ def test_binary_dependency():
     assert status == 0, "Node test script returned non-zero exit code"
     assert output == "Ok\n", "Node script returned wrong output"
 
-    process.kill()
+    kill_process(process)
 
     os.chdir("../")
     with open("stdout.txt", "r") as f:

--- a/test_cron.py
+++ b/test_cron.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script
+from utils import run_node_script, kill_process
 import time
 
 def test_hello():
@@ -62,7 +62,7 @@ def test_hello():
 
     assert numberAfterOneMinute > number, "Cron job did not run"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_dart.py
+++ b/test_dart.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_script
+from utils import run_script, kill_process
 
 def test_dart():
     print("Starting dart sdk test...")
@@ -35,7 +35,7 @@ def test_dart():
 
     print(output)
     assert "100Hello World12hello42true1 21 210 20100 200a1000 10001000 2000b10000 1000010000 10000a20 4020 40b30 6030 603 1 2 33 1 2 33 1 2 33 0 0 1 2 2 43 0 0 1 2 2 43 11 12 13 14 15 161 1 2" in output, "Wrong output from dart test"
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 # Test order matters because the commands are having side effects.

--- a/test_dart_to_python.py
+++ b/test_dart_to_python.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_script, run_node_script, run_npm_run_build
+from utils import run_script, run_node_script, run_npm_run_build, kill_process
 from os.path import exists
 
 def test_dart_to_python():
@@ -41,7 +41,7 @@ def test_dart_to_python():
     assert status == 0, "Node test script returned non-zero exit code"
     assert output in "100string12hello42True[1, 2, 3]['string1', 'string2', 'string3'][1, 2, 3][{'x': 0, 'y': 0}, {'x': 1, 'y': 2}, {'x': 2, 'y': 4}][{'x': 0, 'y': 0}, {'x': 1, 'y': 2}, {'x': 2, 'y': 4}][{'x': 11, 'y': 12}, {'x': 13, 'y': 14}, {'x': 15, 'y': 16}]", "Wrong output from python test: " + output
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 # Test order matters because the commands are having side effects.

--- a/test_dart_typescript_sdk.py
+++ b/test_dart_typescript_sdk.py
@@ -3,7 +3,7 @@
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
 from os.path import exists
-from utils import compare_files
+from utils import compare_files, kill_process
 
 def test_dart_typescript_sdk():
     print("Starting test_dart_typescript_sdk test...")
@@ -29,7 +29,7 @@ def test_dart_typescript_sdk():
 
     assert compare_files("../client/sdk/task.sdk.ts", "../client/todo_list.ts.template") == True, "Wrong class sdk content"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 # Test order matters because the commands are having side effects.

--- a/test_hello.py
+++ b/test_hello.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script
+from utils import run_node_script, kill_process
 
 def test_hello():
     print("Starting hello_world test...")
@@ -44,7 +44,7 @@ def test_hello():
     assert components[0] == "Hello world!", "Node script returned wrong output"
     assert components[1] == "Hello, George, from Tenerife!", "Node script returned wrong output"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_js_sdk.py
+++ b/test_js_sdk.py
@@ -3,6 +3,7 @@
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
 from os.path import exists
+from utils import kill_process
 
 def test_js_sdk():
     print("Starting javascript sdk test...")
@@ -44,7 +45,7 @@ def test_js_sdk():
     assert "static async methodWithOneParameter(test1)" in content, "Wrong exported method with one parameter"
     assert "static async methodWithMultipleParameters(test1, test2)" in content, "Wrong exported method with multiple parameters"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_lambda_handler_errors.py
+++ b/test_lambda_handler_errors.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script
+from utils import run_node_script, kill_process
 
 def test_lambda_handler_errors():
     print("Starting test_lambda_handler_errors test...")
@@ -36,7 +36,7 @@ def test_lambda_handler_errors():
     assert status == 0, "Node test script returned non-zero exit code " + status
     assert output == "Error: Error from server\n", "Node script returned wrong output " + output
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_python_sdk.py
+++ b/test_python_sdk.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_script
+from utils import run_script, kill_process
 from os.path import exists
 
 def test_python_sdk():
@@ -42,7 +42,7 @@ def test_python_sdk():
     assert status == 0, "Node test script returned non-zero exit code"
     assert output in "Nonestringstringstring", "Wrong output from python test: " + output    
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_swift_sdk.py
+++ b/test_swift_sdk.py
@@ -3,6 +3,7 @@
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
 from os.path import exists
+from utils import kill_process
 
 def test_swift_sdk():
     print("Starting swift sdk test...")
@@ -44,7 +45,7 @@ def test_swift_sdk():
     assert "static func methodWithOneParameter(test1: String) async -> String" in content, "Wrong exported method with one parameter"
     assert "static func methodWithMultipleParameters(test1: String, test2: Double) async -> String" in content, "Wrong exported method with multiple parameters"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_todo_list.py
+++ b/test_todo_list.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script
+from utils import run_node_script, kill_process
 
 def test_todo_list():
     print("Starting todo_list test...")
@@ -44,7 +44,7 @@ def test_todo_list():
     for i in range(0, 8):
         assert components[i] == "Ok", "Component " + str(i) + " returned wrong output"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_todo_list_ts.py
+++ b/test_todo_list_ts.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script, run_npm_run_build
+from utils import run_node_script, run_npm_run_build, kill_process
 
 def test_todo_list_ts():
     print("Starting todo_list ts test...")
@@ -50,7 +50,7 @@ def test_todo_list_ts():
     for i in range(0, 8):
         assert components[i] == "Ok", "Component " + str(i) + " returned wrong output"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 # Test order matters because the commands are having side effects.

--- a/test_ts_dev_stage.py
+++ b/test_ts_dev_stage.py
@@ -3,6 +3,7 @@
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
 from os.path import exists
+from utils import kill_process
 
 def test_ts_sdk():
     print("Starting typescript dev stage test...")
@@ -44,7 +45,8 @@ def test_ts_sdk():
     assert "static async methodWithOneParameter(test1: string): Promise<string>" in content, "Wrong exported method with one parameter"
     assert "static async methodWithMultipleParameters(test1: string, test2: number): Promise<string>" in content, "Wrong exported method with multiple parameters"
 
-    process.kill()
+    kill_process(process)
+    
     print("Test passed!")
 
 

--- a/test_ts_sdk.py
+++ b/test_ts_sdk.py
@@ -3,6 +3,7 @@
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
 from os.path import exists
+from utils import kill_process
 
 def test_ts_sdk():
     print("Starting typescript sdk test...")
@@ -44,7 +45,7 @@ def test_ts_sdk():
     assert "static async methodWithOneParameter(test1: string): Promise<string>" in content, "Wrong exported method with one parameter"
     assert "static async methodWithMultipleParameters(test1: string, test2: number): Promise<string>" in content, "Wrong exported method with multiple parameters"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_ts_to_python.py
+++ b/test_ts_to_python.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_npm_run_build, run_script
+from utils import run_npm_run_build, run_script, kill_process
 
 def test_ts_to_python_sdk():
     print("Starting ts to python sdk test...")
@@ -39,7 +39,7 @@ def test_ts_to_python_sdk():
     assert status == 0, "Node test script returned non-zero exit code"
     assert output in "Hello from server!1string2name0typeTrueFalse22[11, 22]None", "Wrong output from python test: " + output
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 # Test order matters because the commands are having side effects.

--- a/test_typescript_flutter_sdk.py
+++ b/test_typescript_flutter_sdk.py
@@ -3,7 +3,7 @@
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
 from os.path import exists
-from utils import compare_files
+from utils import compare_files, kill_process
 
 def test_typescript_flutter_sdk():
     print("Starting test_typescript_flutter_sdk test...")
@@ -29,7 +29,7 @@ def test_typescript_flutter_sdk():
 
     assert compare_files("../client/sdk/chat_backend.dart", "../client/chat_backend.dart.template") == True, "Wrong class sdk content"
 
-    process.kill()
+    kill_process(process)
     print("Test passed!")
 
 

--- a/test_webhooks.py
+++ b/test_webhooks.py
@@ -2,7 +2,7 @@
 
 import os
 from genezio import genezio_deploy, genezio_login, genezio_local
-from utils import run_node_script
+from utils import run_node_script, kill_process
 
 def test_webhooks():
     print("Starting webhook test...")
@@ -43,7 +43,7 @@ def test_webhooks():
     assert components[1] == 'text in body', "Component 1 returned wrong output"
     assert components[2] == "{ name: 'John' }", "Component 2 returned wrong output"
     assert components[3] == "contents of file", "Component 3 returned wrong output"
-    process.kill()
+    kill_process(process)
 
     os.chdir("../")
     print("Test passed!")


### PR DESCRIPTION
The Windows `Popen` has a `shell=True` argument that opens a new shell as a child of a process. In order to stop all the shell commands, we also need to kill the children processes.