### PR TITLE
[bugfix/windows] Close handles after reading files in sdk tests

### DIFF
--- a/test_js_sdk.py
+++ b/test_js_sdk.py
@@ -20,8 +20,8 @@ def test_js_sdk():
     assert exists("../client/sdk/remote.js") == True, "Remote js sdk not found"
     assert exists("../client/sdk/server.sdk.js") == True, "Class js sdk not found"
 
-    f = open("../client/sdk/server.sdk.js", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.js", "r") as f:
+        content = f.read()
 
     assert "static async method()" in content, "Wrong exported method without parameters"
     assert "static async methodWithoutParameters()" in content, "Wrong exported method with return type"
@@ -37,8 +37,8 @@ def test_js_sdk():
     assert exists("../client/sdk/remote.js") == True, "Remote js sdk not found"
     assert exists("../client/sdk/server.sdk.js") == True, "Class js sdk not found"
 
-    f = open("../client/sdk/server.sdk.js", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.js", "r") as f:
+        content = f.read()
 
     assert "static async method()" in content, "Wrong exported method without parameters"
     assert "static async methodWithoutParameters()" in content, "Wrong exported method with return type"

--- a/test_swift_sdk.py
+++ b/test_swift_sdk.py
@@ -20,8 +20,8 @@ def test_swift_sdk():
     assert exists("../client/sdk/remote.swift") == True, "Remote swift sdk not found"
     assert exists("../client/sdk/server.sdk.swift") == True, "Class swift sdk not found"
 
-    f = open("../client/sdk/server.sdk.swift", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.swift", "r") as f:
+        content = f.read()
 
     assert "static func method() async -> Any" in content, "Wrong exported method without parameters"
     assert "static func methodWithoutParameters() async -> String" in content, "Wrong exported method with return type"
@@ -37,8 +37,8 @@ def test_swift_sdk():
     assert exists("../client/sdk/remote.swift") == True, "Remote swift sdk not found"
     assert exists("../client/sdk/server.sdk.swift") == True, "Class swift sdk not found"
 
-    f = open("../client/sdk/server.sdk.swift", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.swift", "r") as f:
+        content = f.read()
 
     assert "static func method() async -> Any" in content, "Wrong exported method without parameters"
     assert "static func methodWithoutParameters() async -> String" in content, "Wrong exported method with return type"

--- a/test_ts_dev_stage.py
+++ b/test_ts_dev_stage.py
@@ -20,8 +20,8 @@ def test_ts_sdk():
     assert exists("../client/sdk/remote.ts") == True, "Remote ts sdk not found"
     assert exists("../client/sdk/server.sdk.ts") == True, "Class ts sdk not found"
 
-    f = open("../client/sdk/server.sdk.ts", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.ts", "r") as f:
+        content = f.read()
 
     assert "static async method()" in content, "Wrong exported method without parameters"
     assert "static async methodWithoutParameters(): Promise<string>" in content, "Wrong exported method with return type"
@@ -37,8 +37,8 @@ def test_ts_sdk():
     assert exists("../client/sdk/remote.ts") == True, "Remote ts sdk not found"
     assert exists("../client/sdk/server.sdk.ts") == True, "Class ts sdk not found"
 
-    f = open("../client/sdk/server.sdk.ts", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.ts", "r") as f:
+        content = f.read()
 
     assert "static async method()" in content, "Wrong exported method without parameters"
     assert "static async methodWithoutParameters(): Promise<string>" in content, "Wrong exported method with return type"

--- a/test_ts_sdk.py
+++ b/test_ts_sdk.py
@@ -20,8 +20,8 @@ def test_ts_sdk():
     assert exists("../client/sdk/remote.ts") == True, "Remote ts sdk not found"
     assert exists("../client/sdk/server.sdk.ts") == True, "Class ts sdk not found"
 
-    f = open("../client/sdk/server.sdk.ts", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.ts", "r") as f:
+        content = f.read()
 
     assert "static async method()" in content, "Wrong exported method without parameters"
     assert "static async methodWithoutParameters(): Promise<string>" in content, "Wrong exported method with return type"
@@ -37,8 +37,8 @@ def test_ts_sdk():
     assert exists("../client/sdk/remote.ts") == True, "Remote ts sdk not found"
     assert exists("../client/sdk/server.sdk.ts") == True, "Class ts sdk not found"
 
-    f = open("../client/sdk/server.sdk.ts", "r")
-    content = f.read()
+    with open("../client/sdk/server.sdk.ts", "r") as f:
+        content = f.read()
 
     assert "static async method()" in content, "Wrong exported method without parameters"
     assert "static async methodWithoutParameters(): Promise<string>" in content, "Wrong exported method with return type"


### PR DESCRIPTION
If we don't close the handles properly, the sdk delete will fail because you can't delete a file that is already in use on Windows.