### PR TITLE
Upgrade third party github actions to use node 20

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,29 +88,29 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.genezio_tests_branch }}
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
       - name: Install Python dependencies
         uses: py-actions/py-dependency-install@v4
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: "Genez-io/genezio"
           ref: ${{ inputs.genezio_branch }}
           path: genezio
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 18
+          node-version: 20
       - name: Get node_modules cache
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v4
         id: node_modules
         with:
           path: |
@@ -182,7 +182,7 @@ jobs:
         if: needs.test.result == 'success'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
-        uses: voxmedia/github-action-slack-notify-build@v1
+        uses: voxmedia/github-action-slack-notify-build@v1.6.0
         with:
           channel_id: C04QR0X8CQ2
           status: SUCCESS
@@ -191,7 +191,7 @@ jobs:
         if: needs.test.result == 'failure'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
-        uses: voxmedia/github-action-slack-notify-build@v1
+        uses: voxmedia/github-action-slack-notify-build@v1.6.0
         with:
           channel_id: C04QR0X8CQ2
           status: FAILED


### PR DESCRIPTION
We are receiving the following warning when running actions:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/setup-node@v3, actions/cache@v3.0.2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Context: [GitHub Changelog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.)

Most of the third party actions we are using already upgraded to node 20.

This PR updates the actions versions to their corresponding latest release.